### PR TITLE
Build updated to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y python python-pip
-RUN pip install flask
+RUN apt-get update && apt-get install -y python3
+RUN apt-get -y install python3-pip
+RUN pip3 install flask
 COPY app.py /opt/
 ENTRYPOINT FLASK_APP=/opt/app.py flask run --host=0.0.0.0 --port=8080


### PR DESCRIPTION
Fix for the Docker build failure

Python version 1 is discontinued completely but the package continued to be named as python2. Similarly, when Python version 3 was released, distributions started providing both python2 and python3 packages. As of now the Python 2 is no longer supported and Python 3.x is what you get on Ubuntu. 

The package is named as python3.  