### PR TITLE
Python 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-RUN apt-get update && apt-get install -y python python-pip
+RUN apt-get update && apt-get install -y python3 python3-pip
 RUN pip install flask
 COPY app.py /opt/
 ENTRYPOINT FLASK_APP=/opt/app.py flask run --host=0.0.0.0 --port=8080

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is used in the demonstration of development of Ansible Playbooks.
   
   Python and its dependencies
 
-    apt-get install -y python python-setuptools python-dev build-essential python-pip python-mysqldb
+    apt-get install -y python3 python3-setuptools python3-dev build-essential python3-pip python3-mysqldb
 
    
 ## 2. Install and Configure Web Server


### PR DESCRIPTION
Python 2.x has been deprecated, and Python 3.x should be used.